### PR TITLE
Get-AzureADGroup revised

### DIFF
--- a/WVDSync.psm1
+++ b/WVDSync.psm1
@@ -58,7 +58,7 @@ Function GetRDSAppMembers ($RDSTenantName, $HostPoolName, $AppGroupName) {
 }
 Function GetAzureADGroupMembers ($AADGroupName){
     #Retrieves the members of an AAD group
-    $AzureADGroup=Get-AzureADGroup | Where-Object DisplayName -eq $AADGroupName
+    $AzureADGroup=Get-AzureADGroup -searchstring $AADGroupName
 
     If (!($AzureADGroup)){
         return $false
@@ -185,7 +185,7 @@ Function GeneratePassword2{
 }
 
 Function Validate-AADGroup ($Group) {
-    $AzureADGroup=Get-AzureADGroup | Where-Object DisplayName -eq $Group
+    $AzureADGroup=Get-AzureADGroup -searchstring $Group
     If ($AzureADGroup) {
         return $true
     }else{


### PR DESCRIPTION
Modified Get-AzureADGroup syntax in both functions "GetAzureADGroupMembers" and "Validate-AADGroup" to enumerate more than 100 members.
Note: Get-AzureADGroup -searchstring is faster but it looks for a string, it could cause exception is the string is found in the display name of more than 1 group.
Slower but safe: Get-AzureADGroup -all $true